### PR TITLE
Remove leading and trailing whitespace in roles

### DIFF
--- a/lib/capistrano/dsl/aws.rb
+++ b/lib/capistrano/dsl/aws.rb
@@ -9,7 +9,7 @@ module Capistrano
       def aws_ec2_register(options = {})
         aws_ec2.instances.each do |_id, instance|
           ip = Capistrano::Aws::EC2.contact_point(instance)
-          roles = Capistrano::Aws::EC2.parse_tag(instance, fetch(:aws_ec2_roles_tag)).split(',')
+          roles = Capistrano::Aws::EC2.parse_tag(instance, fetch(:aws_ec2_roles_tag)).split(",").map(&:strip)
 
           server ip, options.merge(roles: roles, aws_instance_id: instance.id)
         end


### PR DESCRIPTION
This supports comma separated list with space, see:

```ruby
irb(main):001:0> "web, app".split(",").map(&:strip)
=> ["web", "app"]
irb(main):002:0> "web, app".split(",")
=> ["web", " app"]
```

we don't want space in the role name