### PR TITLE
Fix uninitialized constant SSHKit

### DIFF
--- a/lib/capistrano/aws.rb
+++ b/lib/capistrano/aws.rb
@@ -1,5 +1,7 @@
+require 'sshkit'
 require 'capistrano/aws/ec2/ec2'
 require 'capistrano/dsl/aws'
+
 extend Capistrano::DSL::Aws
 
 SSHKit::Backend::Netssh.send(:include, Capistrano::DSL::Aws)


### PR DESCRIPTION
Avoid getting `NameError: uninitialized constant SSHKit`

This is not an issue if you have `sshkit` in your Gemfile BEFORE `capistrano-aws`, but relying on Gemfile order is not safe :)