### PR TITLE
Update README to for aws_ec2_register

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The AWS credentials are loaded from your system. Check https://github.com/aws/aw
 
 The instances must be registered in each stage. In your `config/deploy/<stage_name>.rb`, add the following line:
 
+*This must be placed after you have configured your AWS settings*
 ```ruby
 aws_ec2_register
 ```


### PR DESCRIPTION
This informs the user that his function should be placed after AWS settings have been set.