### PR TITLE
Allow default filters to be overridden

### DIFF
--- a/lib/capistrano/aws/ec2/ec2.rb
+++ b/lib/capistrano/aws/ec2/ec2.rb
@@ -22,25 +22,9 @@ module Capistrano
         end
 
         def instances
-          application = fetch(:aws_ec2_application)
-          raise 'application not set.' if application.nil?
-
           instances = {}
 
-          filters = [
-            {
-              name: "tag:#{fetch(:aws_ec2_application_tag)}",
-              values: [fetch(:aws_ec2_application)]
-            },
-            {
-              name: "tag:#{fetch(:aws_ec2_stage_tag)}",
-              values: [fetch(:aws_ec2_stage)]
-            },
-            {
-              name: 'instance-state-name',
-              values: ['running']
-            }
-          ]
+          filters = fetch(:aws_ec2_default_filters)
 
           filters.concat fetch(:aws_ec2_extra_filters)
 

--- a/lib/capistrano/tasks/defaults.rake
+++ b/lib/capistrano/tasks/defaults.rake
@@ -18,6 +18,24 @@ namespace :load do
     # Tag to be used for Capistrano roles of the server (the tag value can be a comma separated list).
     set :aws_ec2_roles_tag, 'Roles'
 
+    # Default filters used for all requests, set to an empty array [] to disable completely
+    set :aws_ec2_default_filters, (proc {
+      [
+        {
+          name: "tag:#{fetch(:aws_ec2_application_tag)}",
+          values: [fetch(:aws_ec2_application)]
+        },
+        {
+          name: "tag:#{fetch(:aws_ec2_stage_tag)}",
+          values: [fetch(:aws_ec2_stage)]
+        },
+        {
+          name: 'instance-state-name',
+          values: ['running']
+        }
+      ]
+    })
+
     # Extra filters to be used to retrieve the instances. See the README.md for more information.
     set :aws_ec2_extra_filters, []
 


### PR DESCRIPTION
@fernandocarletti I figured it might be easier to talk in code than discuss options as it's pretty simple code anyway 😀

This is an example of what I was originally thinking which would send the `Application` filter if it's set, or not send it at all if it's undefined.