### PR TITLE
Private DNS and instance ID for aws_ec2_contact_point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2020-04-22 - 1.2.2 - Extra EC2 contact point
+
+* Added extra EC2 contact point with instance id and private DNS (for SSM usage)
+
 2018-03-08 - 1.1.0 - Custom filters
 
 * Support extra filters for retrieving EC2 instances.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ set :aws_ec2_extra_filters, []
 # Tag to be used as the instance name in the instances table (aws:ec2:instances task).
 set :aws_ec2_name_tag, 'Name'
 
-# How to contact the instance (:public_ip, :public_dns, :private_ip).
+# How to contact the instance (:public_ip, :public_dns, :private_ip, :private_dns, :id).
 set :aws_ec2_contact_point, :public_ip
 ```
 

--- a/capistrano-aws.gemspec
+++ b/capistrano-aws.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name = 'capistrano-aws'
-  gem.version = '1.2.1'
+  gem.version = '1.2.2'
   gem.author = 'Fernando Carletti'
   gem.email = 'contact@fernandocarletti.net'
   gem.homepage = 'http://github.com/fernandocarletti/capistrano-aws'

--- a/lib/capistrano/aws/ec2/ec2.rb
+++ b/lib/capistrano/aws/ec2/ec2.rb
@@ -42,6 +42,10 @@ module Capistrano
         case fetch(:aws_ec2_contact_point)
         when :private_ip
           instance.private_ip_address
+        when :private_dns
+          instance.private_dns_name
+        when :id
+          instance.id
         when :public_dns
           instance.public_dns_name
         else

--- a/lib/capistrano/tasks/defaults.rake
+++ b/lib/capistrano/tasks/defaults.rake
@@ -42,7 +42,7 @@ namespace :load do
     # Tag to be used as the instance name in the instances table (aws:ec2:instances task).
     set :aws_ec2_name_tag, 'Name'
 
-    # How to contact the instance (:public_ip, :public_dns, :private_ip).
+    # How to contact the instance (:public_ip, :public_dns, :private_ip, :private_dns, :id).
     set :aws_ec2_contact_point, :public_ip
   end
 end


### PR DESCRIPTION
To be able to use AWS SSM to connect to the EC2 instances (and not open SSH service to the world), it's required to use the instance identifier of the private DNS.

- added the available values of `:private_dns` and `:id` for the `aws_ec2_contact_point` configuration
- proposal for an increase in library version and updated changelog

Changes are not breaking compatibility with previous library usages.