### PR TITLE
Update aws_ec2_contact_point options to include :ipv_6_address

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ set :aws_ec2_extra_filters, []
 # Tag to be used as the instance name in the instances table (aws:ec2:instances task).
 set :aws_ec2_name_tag, 'Name'
 
-# How to contact the instance (:public_ip, :public_dns, :private_ip, :private_dns, :id).
+# How to contact the instance (:public_ip, :public_dns, :private_ip, :private_dns, :id, :ipv_6_address).
 set :aws_ec2_contact_point, :public_ip
 ```
 

--- a/lib/capistrano/aws/ec2/ec2.rb
+++ b/lib/capistrano/aws/ec2/ec2.rb
@@ -48,6 +48,8 @@ module Capistrano
           instance.id
         when :public_dns
           instance.public_dns_name
+        when :ipv_6_address
+          "[#{instance.ipv_6_address}]"
         else
           instance.public_ip_address
         end

--- a/lib/capistrano/tasks/defaults.rake
+++ b/lib/capistrano/tasks/defaults.rake
@@ -42,7 +42,7 @@ namespace :load do
     # Tag to be used as the instance name in the instances table (aws:ec2:instances task).
     set :aws_ec2_name_tag, 'Name'
 
-    # How to contact the instance (:public_ip, :public_dns, :private_ip, :private_dns, :id).
+    # How to contact the instance (:public_ip, :public_dns, :private_ip, :private_dns, :id, :ipv_6_address).
     set :aws_ec2_contact_point, :public_ip
   end
 end


### PR DESCRIPTION
Hi, I am using this great gem.
I added the functionality to be able to deploy on ipv6 as well.

The fixes are small, but I would appreciate it if you could merge them when you have time.

Thank you,
